### PR TITLE
build: change dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "author": "",
   "license": "ISC",
-  "dependencies": {
+  "devDependencies": {
     "typescript": "^3.3.3333"
   }
 }


### PR DESCRIPTION
Typescript is a dev dep. When ts-pq is added in a project, it should not add typescript as a dep.